### PR TITLE
Add support for MacOSX

### DIFF
--- a/src/opencl4py/_cffi.py
+++ b/src/opencl4py/_cffi.py
@@ -556,7 +556,7 @@ def _initialize(backends):
         raise OSError("Could not load OpenCL library")
 
 
-def initialize(backends=("libOpenCL.so", "OpenCL.dll")):
+def initialize(backends=("libOpenCL.so", "OpenCL.dll", "OpenCL")):
     global lib
     if lib is not None:
         return


### PR DESCRIPTION
/System/Library/Frameworks/OpenCL.framework/OpenCL is the needed shared library; /System/Library/Frameworks/OpenCL.framework is on the library search path so we should just add "OpenCL"

```
In [6]: opencl4py.Platforms().platforms[0].devices
Out[6]: 
[<opencl4py.Device 'Intel(R) Core(TM) i5-3210M CPU @ 2.50GHz'>,
 <opencl4py.Device 'HD Graphics 4000'>]
```